### PR TITLE
Custom build adapter seems unnecessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,5 @@ help:
 		| sed -e "s/^Makefile://" -e "s///" \
 		| awk 'BEGIN { FS = ":.*?## " }; { printf "\033[36m%-30s\033[0m %s\n", $$1, $$2 }'
 
-install: ## Install dependencies
-	test -s wasi_snapshot_preview1.reactor.wasm || \
-	curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v25.0.2/wasi_snapshot_preview1.reactor.wasm
-
 build: ## Build the wasi component
 	npm run build

--- a/README.md
+++ b/README.md
@@ -34,6 +34,5 @@ $ npm install
 ## Building
 
 ```shell
-$ make install
 $ npm run build
 ```

--- a/build.mjs
+++ b/build.mjs
@@ -7,7 +7,6 @@ const componentSource = await readFile('src/index.js', 'utf-8');
 
 const { component } = await componentize(componentSource, {
   witPath: resolve('./wit/protocols.wit'),
-  preview2Adapter: resolve('./wasi_snapshot_preview1.reactor.wasm'),
   worldName: 'data-collection',
   enableAot: process.env.ENABLE_AOT == '1',
   disableFeatures: [ 'http' ],


### PR DESCRIPTION
If I remove the custom adapter (which is an optional parameter) I end up with a near identical build. The resulting binary is nearly identical, I've checked the resulting binary with the [Wasm Analyzer](https://wa2.dev/) and it shows identical imports/exports, it seems to me it uses a slightly different wasmtime version by default.

I don't know how to actually test this one, any tips?