### PR TITLE
feat: disable only http WIT interface by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "./types/wit.d.ts",
   "scripts": {
     "generate": "npx @bytecodealliance/jco types .edgee/wit -o types/",
-    "build": "npx @bytecodealliance/jco componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -n data-collection -d all",
+    "build": "npx @bytecodealliance/jco componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -n data-collection -d http",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"
   },


### PR DESCRIPTION
### Description of Changes

We used to disable all WASI interfaces, but we should only restrict http and allow everything else by default.

Why?

When you use `--disable all`, your component won't get access to any WASI interfaces that might be useful for debugging or logging. For example:
- you can't `console.log(...)` or `console.error(...)` without `stdio`
- you can't use `Math.random()` without `random`
- you can't use `Date.now()` or `new Date()` without `clocks`

This is very tricky because calls to `Math.random()` or `Date.now()` will return seemingly valid outputs, but without actual randomness or timestamp correctness.

In practice, `Math.random()` would always return the same value. And `Date.now()` would always return the same timestamp.

So this would be pretty challenging to debug in production because no errors/exceptions are raised. To me, it sounds like a good idea to enable real randomness and real dates by default for Edgee components.