### PR TITLE
Update build commands with componentize-js fix

### DIFF
--- a/data-collection/package.json
+++ b/data-collection/package.json
@@ -4,9 +4,9 @@
   "main": "src/index.js",
   "types": "./types/wit.d.ts",
   "scripts": {
-    "generate": "npx @bytecodealliance/jco types .edgee/wit -o types/",
-    "build-jco": "npx @bytecodealliance/jco@1.12.1 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
-    "build": "npx @bytecodealliance/componentize-js@0.18.4 src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
+    "generate": "npx @bytecodealliance/jco@1.13.0 types .edgee/wit -o types/",
+    "build": "npx @bytecodealliance/jco@1.13.0 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
+    "build-componentize": "npx @bytecodealliance/componentize-js@0.18.4 src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"
   },

--- a/data-collection/package.json
+++ b/data-collection/package.json
@@ -5,7 +5,8 @@
   "types": "./types/wit.d.ts",
   "scripts": {
     "generate": "npx @bytecodealliance/jco types .edgee/wit -o types/",
-    "build": "npx @bytecodealliance/jco@1.11.3 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -n data-collection -d http",
+    "build-jco": "npx @bytecodealliance/jco@1.12.1 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
+    "build": "npx @bytecodealliance/componentize-js@0.18.4 src/index.js --wit .edgee/wit -o example-js-component.wasm -d http -d fetch-event",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"
   },

--- a/edge-function/package.json
+++ b/edge-function/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "generate": "npx @bytecodealliance/jco@1.13.0 types .edgee/wit -o types/",
     "bundle": "npx esbuild src/index.js --bundle --format=esm --platform=neutral --external:wasi:* --outfile=dist/index.js --target=es2020",
-    "build": "npm run bundle && npx @bytecodealliance/jco@1.13.0 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm",
+    "build": "npm run bundle && npx @bytecodealliance/jco@1.13.0 componentize dist/index.js --wit .edgee/wit -o example-js-component.wasm",
     "build-componentize": "npm run bundle && npx @bytecodealliance/componentize-js@0.18.4 dist/index.js --wit .edgee/wit -o example-js-edge-function-component.wasm",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"

--- a/edge-function/package.json
+++ b/edge-function/package.json
@@ -4,10 +4,10 @@
   "main": "dist/index.js",
   "types": "./types/wit.d.ts",
   "scripts": {
-    "generate": "npx @bytecodealliance/jco types .edgee/wit -o types/",
+    "generate": "npx @bytecodealliance/jco@1.13.0 types .edgee/wit -o types/",
     "bundle": "npx esbuild src/index.js --bundle --format=esm --platform=neutral --external:wasi:* --outfile=dist/index.js --target=es2020",
-    "build": "npm run bundle && npx @bytecodealliance/componentize-js@0.18.4 dist/index.js --wit .edgee/wit -o example-js-edge-function-component.wasm",
-    "build-jco": "npm run bundle && npx @bytecodealliance/jco@1.12.1 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm",
+    "build": "npm run bundle && npx @bytecodealliance/jco@1.13.0 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm",
+    "build-componentize": "npm run bundle && npx @bytecodealliance/componentize-js@0.18.4 dist/index.js --wit .edgee/wit -o example-js-edge-function-component.wasm",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"
   },

--- a/edge-function/package.json
+++ b/edge-function/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "generate": "npx @bytecodealliance/jco types .edgee/wit -o types/",
     "bundle": "npx esbuild src/index.js --bundle --format=esm --platform=neutral --external:wasi:* --outfile=dist/index.js --target=es2020",
-    "build": "npm run bundle && npx @bytecodealliance/jco componentize dist/index.js --wit .edgee/wit -o example-js-edge-function-component.wasm -n edge-function",
+    "build": "npm run bundle && npx @bytecodealliance/componentize-js@0.18.4 dist/index.js --wit .edgee/wit -o example-js-edge-function-component.wasm",
+    "build-jco": "npm run bundle && npx @bytecodealliance/jco@1.12.1 componentize src/index.js --wit .edgee/wit -o example-js-component.wasm",
     "test": "mocha",
     "coverage": "c8 --src js --all -r text -r text-summary npm test"
   },


### PR DESCRIPTION
### Description of Changes

- use `componentize-js` directly for default build script
- add build-jco command too (mainly for debugging and quickly checking compatibility)
- pinpoint both to upcoming release versions (WIP)
- add `-d fetch-event` for data collection (in addition to `-d http`)

